### PR TITLE
chore: migrate CI runners to WarpBuild

### DIFF
--- a/.github/workflows/bandit.yml
+++ b/.github/workflows/bandit.yml
@@ -14,7 +14,7 @@ permissions:
 
 jobs:
   build:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-arm64-2x
     steps:
       - uses: actions/checkout@v3
       - name: Set up Python ${{ matrix.python-version }}

--- a/.github/workflows/git-hygiene.yml
+++ b/.github/workflows/git-hygiene.yml
@@ -10,7 +10,7 @@ jobs:
     permissions:
       issues: write
       pull-requests: write
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-arm64-2x
     name: Stale issue job
     steps:
     - uses: actions/stale@v4

--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -27,7 +27,7 @@ concurrency:
 jobs:
   # Build job
   build:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-arm64-2x
     defaults:
       run:
         working-directory: docs
@@ -68,7 +68,7 @@ jobs:
     environment:
       name: github-pages
       url: ${{ steps.deployment.outputs.page_url }}
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-arm64-2x
     needs: build
     steps:
       - name: Deploy to GitHub Pages

--- a/.github/workflows/snyk.yml
+++ b/.github/workflows/snyk.yml
@@ -9,7 +9,7 @@ on:
     - main
 jobs:
   security:
-    runs-on: ubuntu-latest
+    runs-on: warp-ubuntu-2404-arm64-2x
     steps:
       - uses: actions/checkout@master
       - name: Run Snyk to check for vulnerabilities


### PR DESCRIPTION
Replaces GitHub-hosted `ubuntu-latest` runner with WarpBuild `warp-ubuntu-2404-arm64-2x` in `bandit.yml`, `git-hygiene.yml`, `pages.yml`, and `snyk.yml`.

Part of org-wide migration away from GitHub-hosted runners.